### PR TITLE
chore: add `.luarc.json` for improved Lua diagnostics

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,16 @@
+{
+  "diagnostics.groupFileStatus": {
+    "ambiguity": "Opened",
+    "await": "Opened",
+    "codestyle": "Opened",
+    "duplicate": "Opened",
+    "global": "Opened",
+    "luadoc": "Opened",
+    "redefined": "Opened",
+    "strict": "Opened",
+    "strong": "Opened",
+    "type-check": "Opened",
+    "unbalanced": "Opened",
+    "unused": "Opened"
+  }
+}


### PR DESCRIPTION
We will use `Opened` for all categories to cover all diagnostics without
being bothered by unannotated libraries.
