### PR TITLE
ci: use `find` instead of globbing for `msgfmt --check`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,7 @@ jobs:
         run: sudo apt-get install -y gettext
 
       - name: Run msgfmt
-        run: |
-          shopt -s globstar
-          msgfmt --check --output-file=/dev/null **/*.po
+        run: find . -name '*.po' -exec msgfmt --check --output-file=/dev/null {} \;
 
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`msgfmt` complains about the entries with the same `msgid` even if they
are in different files when we run it with globbing.
